### PR TITLE
Family image

### DIFF
--- a/lib/image.ml
+++ b/lib/image.ml
@@ -20,19 +20,19 @@ let default_portrait_filename base p =
   default_portrait_filename_of_key (p_first_name base p) (p_surname base p)
     (get_occ p)
 
-(** [default_family_portrait_filename_of_key fn sn occ] is the default filename
+(** [default_blason_filename_of_key fn sn occ] is the default filename
  of the corresponding person's portrait. WITHOUT its file extenssion.
  e.g: default_portrait_filename_of_key "Jean Claude" "DUPOND" 3 is "jean_claude.3.dupond"
  *)
-let default_family_portrait_filename_of_key first_name surname occ =
+let default_blason_filename_of_key first_name surname occ =
   let space_to_unders = Mutil.tr ' ' '_' in
   let f = space_to_unders (Name.lower first_name) in
   let s = space_to_unders (Name.lower surname) in
   Format.sprintf "%s.%d.%s.family" f occ s
 
-let default_family_portrait_filename base p =
-  default_family_portrait_filename_of_key (p_first_name base p)
-    (p_surname base p) (get_occ p)
+let default_blason_filename base p =
+  default_blason_filename_of_key (p_first_name base p) (p_surname base p)
+    (get_occ p)
 
 let authorized_image_file_extension = [| ".jpg"; ".jpeg"; ".png"; ".gif" |]
 
@@ -65,11 +65,11 @@ let full_portrait_path conf base p =
   | None ->
       None
 
-(** [full_family_portrait_path conf base p] is [Some path] if [p] has a portrait.
+(** [full_blason_path conf base p] is [Some path] if [p] has a portrait.
     [path] is a the full path of the file with file extension. *)
-let full_family_portrait_path conf base p =
+let full_blason_path conf base p =
   (* TODO why is extension not in filename..? *)
-  let s = default_family_portrait_filename base p in
+  let s = default_blason_filename base p in
   let f = Filename.concat (portrait_folder conf) s in
   match find_img_opt f with
   | Some (`Path p) -> p
@@ -215,14 +215,13 @@ let has_access_to_portrait conf base p =
      && is_not_private_img conf (sou base img)
 (* TODO: privacy settings should be in db not in url *)
 
-(** [has_access_to_family_portrait conf base p] is true iif we can see [p]'s portrait. *)
-let has_access_to_family_portrait conf base p =
+(** [has_access_to_blason conf base p] is true iif we can see [p]'s portrait. *)
+let has_access_to_blason conf base p =
   let img = get_image p in
   (conf.wizard || conf.friend)
   || (not conf.no_image)
      && Util.authorized_age conf base p
-     && ((not (is_empty_string img))
-        || full_family_portrait_path conf base p <> "")
+     && ((not (is_empty_string img)) || full_blason_path conf base p <> "")
      && is_not_private_img conf (sou base img)
 (* TODO: privacy settings should be in db not in url *)
 
@@ -284,10 +283,10 @@ let get_portrait conf base p =
   else None
 
 (* if self = true, then do not loop for fathers *)
-let get_family_portrait conf base p self =
-  if has_access_to_family_portrait conf base p then
+let get_blason conf base p self =
+  if has_access_to_blason conf base p then
     let rec loop p =
-      match src_of_string conf (full_family_portrait_path conf base p) with
+      match src_of_string conf (full_blason_path conf base p) with
       | `Src_with_size_info _s as s_info -> (
           match parse_src_with_size_info conf s_info with
           | Error _e -> None
@@ -322,9 +321,9 @@ let get_old_portrait conf base p =
    - the image as the original image.jpg/png/tif image
    - the url to the image as content of a image.url text file
 *)
-let get_old_family_portrait conf base p =
-  if has_access_to_family_portrait conf base p then
-    let key = default_family_portrait_filename base p in
+let get_old_blason conf base p =
+  if has_access_to_blason conf base p then
+    let key = default_blason_filename base p in
     let f =
       Filename.concat (Filename.concat (portrait_folder conf) "old") key
     in
@@ -392,10 +391,10 @@ let get_portrait_with_size conf base p =
         | None -> None)
   else None
 
-let get_family_portrait_with_size conf base p self =
-  if has_access_to_family_portrait conf base p then
+let get_blason_with_size conf base p self =
+  if has_access_to_blason conf base p then
     let rec loop p =
-      match src_of_string conf (full_family_portrait_path conf base p) with
+      match src_of_string conf (full_blason_path conf base p) with
       | `Src_with_size_info _s as s_info -> (
           match parse_src_with_size_info conf s_info with
           | Error _e -> None
@@ -412,7 +411,7 @@ let get_family_portrait_with_size conf base p self =
               let fa = poi base (get_father cpl) in
               loop fa
           | _ -> (
-              match full_family_portrait_path conf base p with
+              match full_blason_path conf base p with
               | "" -> None
               | path ->
                   Some

--- a/lib/image.ml
+++ b/lib/image.ml
@@ -21,14 +21,15 @@ let default_portrait_filename base p =
     (get_occ p)
 
 (** [default_blason_filename_of_key fn sn occ] is the default filename
- of the corresponding person's portrait. WITHOUT its file extenssion.
- e.g: default_portrait_filename_of_key "Jean Claude" "DUPOND" 3 is "jean_claude.3.dupond"
+ of the corresponding person's blason. WITHOUT its file extenssion.
+ e.g: default_blason_filename_of_key "Jean Claude" "DUPOND" 3
+ is "jean_claude.3.dupond.blason"
  *)
 let default_blason_filename_of_key first_name surname occ =
   let space_to_unders = Mutil.tr ' ' '_' in
   let f = space_to_unders (Name.lower first_name) in
   let s = space_to_unders (Name.lower surname) in
-  Format.sprintf "%s.%d.%s.family" f occ s
+  Format.sprintf "%s.%d.%s.blason" f occ s
 
 let default_blason_filename base p =
   default_blason_filename_of_key (p_first_name base p) (p_surname base p)
@@ -48,9 +49,12 @@ let find_img_opt f =
       close_in ic;
       Some (`Url url)
   | None -> (
-      match Mutil.array_find_map exists authorized_image_file_extension with
-      | None -> None
-      | Some f -> Some (`Path f))
+      match exists ".stop" with
+      | Some f -> Some (`Path f)
+      | None -> (
+          match Mutil.array_find_map exists authorized_image_file_extension with
+          | None -> None
+          | Some f -> Some (`Path f)))
 
 (** [full_portrait_path conf base p] is [Some path] if [p] has a portrait.
     [path] is a the full path of the file with file extension. *)
@@ -65,7 +69,7 @@ let full_portrait_path conf base p =
   | None ->
       None
 
-(** [full_blason_path conf base p] is [Some path] if [p] has a portrait.
+(** [full_blason_path conf base p] is [Some path] if [p] has a blason.
     [path] is a the full path of the file with file extension. *)
 let full_blason_path conf base p =
   (* TODO why is extension not in filename..? *)

--- a/lib/image.mli
+++ b/lib/image.mli
@@ -59,6 +59,7 @@ val get_family_portrait_with_size :
   config ->
   base ->
   person ->
+  bool ->
   ([> `Path of string | `Url of string ] * (int * int) option) option
 (** [get_family_portrait_with_size conf base p] is
         - [None] if we don't have access to [p]'s family portrait or it doesn't exist.
@@ -72,7 +73,11 @@ val get_portrait :
 *)
 
 val get_family_portrait :
-  config -> base -> person -> [> `Path of string | `Url of string ] option
+  config ->
+  base ->
+  person ->
+  bool ->
+  [> `Path of string | `Url of string ] option
 (** [get_portrait conf base p] is
     - [None] if we don't have access to [p]'s portrait or it doesn't exist.
     - [Some src] with [src] the url or path of [p]'s portrait.

--- a/lib/image.mli
+++ b/lib/image.mli
@@ -18,9 +18,9 @@ val default_portrait_filename : base -> person -> string
  *)
 
 (* TODO this should be removed *)
-val default_family_portrait_filename : base -> person -> string
-(** [default_family_portrait_filename base p] is the default filename of [p]'s family portrait. Without it's file extension.
- e.g: default_family_portrait_filename_of_key "DUPOND" is "family.dupond"
+val default_blason_filename : base -> person -> string
+(** [default_blason_filename base p] is the default filename of [p]'s family portrait. Without it's file extension.
+ e.g: default_blason_filename_of_key "DUPOND" is "family.dupond"
  *)
 
 val size_from_path : [ `Path of string ] -> (int * int, unit) result
@@ -55,13 +55,13 @@ val get_portrait_with_size :
     - [None] if we don't have access to [p]'s portrait or it doesn't exist.
     - [Some (src, size_opt)] with [src] the url or path of [p]'s portrait. [size_opt] is the (width,height) of the portrait if we could recover them *)
 
-val get_family_portrait_with_size :
+val get_blason_with_size :
   config ->
   base ->
   person ->
   bool ->
   ([> `Path of string | `Url of string ] * (int * int) option) option
-(** [get_family_portrait_with_size conf base p] is
+(** [get_blason_with_size conf base p] is
         - [None] if we don't have access to [p]'s family portrait or it doesn't exist.
         - [Some (src, size_opt)] with [src] the url or path of [p]'s family portrait. [size_opt] is the (width,height) of the family portrait if we could recover them *)
 
@@ -72,7 +72,7 @@ val get_portrait :
     - [Some src] with [src] the url or path of [p]'s portrait.
 *)
 
-val get_family_portrait :
+val get_blason :
   config ->
   base ->
   person ->
@@ -90,9 +90,9 @@ val get_old_portrait :
     - [Some src] with [src] the url or path of [p]'s portrait.
 *)
 
-val get_old_family_portrait :
+val get_old_blason :
   config -> base -> person -> [> `Path of string | `Url of string ] option
-(** [get_old_family_portrait conf base p] is
+(** [get_old_blason conf base p] is
     - [None] if we don't have access to [p]'s family image or it doesn't exist.
     - [Some src] with [src] the url or path of [p]'s family image.
 *)

--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -286,7 +286,7 @@ let print_send_image conf base p =
 
 let print_send_family_image conf base p =
   let title h =
-    if Option.is_some @@ Image.get_family_portrait conf base p then
+    if Option.is_some @@ Image.get_family_portrait conf base p true then
       transl_nth conf "image/images" 0
       |> transl_decline conf "modify"
       |> Utf8.capitalize_fst |> Output.print_sstring conf
@@ -542,7 +542,7 @@ let effective_send_c_ok ?(portrait = true) conf base p file file_name =
   if mode = "portraits" then
     match
       if portrait then Image.get_portrait conf base p
-      else Image.get_family_portrait conf base p
+      else Image.get_family_portrait conf base p true
     with
     | Some (`Path portrait) ->
         if move_file_to_save portrait dir = 0 then
@@ -752,7 +752,7 @@ let effective_reset_c_ok ?(portrait = true) conf base p =
   else
     match
       if portrait then Image.get_portrait conf base p
-      else Image.get_family_portrait conf base p
+      else Image.get_family_portrait conf base p true
     with
     | Some (`Url url) -> (
         try write_file file_in_new url
@@ -905,10 +905,9 @@ let print_c ?(saved = false) ?(portrait = true) conf base =
   | Some f, _ -> ImageDisplay.print_source conf f
   | _, Some p -> (
       match
-        (if saved then Image.get_old_portrait
-        else if portrait then Image.get_portrait
-        else Image.get_family_portrait)
-          conf base p
+        if saved then Image.get_old_portrait conf base p
+        else if portrait then Image.get_portrait conf base p
+        else Image.get_family_portrait conf base p false
       with
       | Some (`Path f) ->
           Result.fold ~ok:ignore

--- a/lib/imageCarrousel.ml
+++ b/lib/imageCarrousel.ml
@@ -286,7 +286,7 @@ let print_send_image conf base p =
 
 let print_send_family_image conf base p =
   let title h =
-    if Option.is_some @@ Image.get_family_portrait conf base p true then
+    if Option.is_some @@ Image.get_blason conf base p true then
       transl_nth conf "image/images" 0
       |> transl_decline conf "modify"
       |> Utf8.capitalize_fst |> Output.print_sstring conf
@@ -428,7 +428,7 @@ let effective_family_send_ok conf base p file =
             error_too_big_image conf base p (String.length content) len
         | _ -> (typ, content))
   in
-  let fname = Image.default_family_portrait_filename base p in
+  let fname = Image.default_blason_filename base p in
   let dir = Util.base_path [ "images" ] conf.bname in
   if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
   let fname =
@@ -525,7 +525,7 @@ let effective_send_c_ok ?(portrait = true) conf base p file file_name =
   in
   let fname =
     if portrait then Image.default_portrait_filename base p
-    else Image.default_family_portrait_filename base p
+    else Image.default_blason_filename base p
   in
   let dir =
     if mode = "portraits" then
@@ -542,7 +542,7 @@ let effective_send_c_ok ?(portrait = true) conf base p file file_name =
   if mode = "portraits" then
     match
       if portrait then Image.get_portrait conf base p
-      else Image.get_family_portrait conf base p true
+      else Image.get_blason conf base p true
     with
     | Some (`Path portrait) ->
         if move_file_to_save portrait dir = 0 then
@@ -550,7 +550,7 @@ let effective_send_c_ok ?(portrait = true) conf base p file file_name =
     | Some (`Url url) -> (
         let fname =
           if portrait then Image.default_portrait_filename base p
-          else Image.default_family_portrait_filename base p
+          else Image.default_blason_filename base p
         in
         let dir = Filename.concat dir "old" in
         if not (Sys.file_exists dir) then Mutil.mkdir_p dir;
@@ -683,7 +683,7 @@ let print_del conf base =
 let effective_delete_c_ok ?(portrait = true) conf base p =
   let fname =
     if portrait then Image.default_portrait_filename base p
-    else Image.default_family_portrait_filename base p
+    else Image.default_blason_filename base p
   in
   let file_name =
     try List.assoc "file_name" conf.env with Not_found -> Adef.encoded ""
@@ -724,7 +724,7 @@ let effective_reset_c_ok ?(portrait = true) conf base p =
   in
   let carrousel =
     if portrait then Image.default_portrait_filename base p
-    else Image.default_family_portrait_filename base p
+    else Image.default_blason_filename base p
   in
   let file_name =
     try List.assoc "file_name" conf.env with Not_found -> Adef.encoded ""
@@ -752,7 +752,7 @@ let effective_reset_c_ok ?(portrait = true) conf base p =
   else
     match
       if portrait then Image.get_portrait conf base p
-      else Image.get_family_portrait conf base p true
+      else Image.get_blason conf base p true
     with
     | Some (`Url url) -> (
         try write_file file_in_new url
@@ -898,7 +898,7 @@ let print_c ?(saved = false) ?(portrait = true) conf base =
   | Some f, Some p ->
       let k =
         if portrait then Image.default_portrait_filename base p
-        else Image.default_family_portrait_filename base p
+        else Image.default_blason_filename base p
       in
       let f = Filename.concat k f in
       ImageDisplay.print_source conf (if saved then insert_saved f else f)
@@ -907,7 +907,7 @@ let print_c ?(saved = false) ?(portrait = true) conf base =
       match
         if saved then Image.get_old_portrait conf base p
         else if portrait then Image.get_portrait conf base p
-        else Image.get_family_portrait conf base p false
+        else Image.get_blason conf base p false
       with
       | Some (`Path f) ->
           Result.fold ~ok:ignore

--- a/lib/imageDisplay.ml
+++ b/lib/imageDisplay.ml
@@ -113,7 +113,7 @@ let print_portrait conf base p =
   | None -> Hutil.incorrect_request conf
 
 (* ********************************************************************************* *)
-(*  [Fonc] print_family_portrait : Config.config -> Gwdb.base -> Gwdb.person -> unit *)
+(*  [Fonc] print_blason : Config.config -> Gwdb.base -> Gwdb.person -> unit *)
 (* ********************************************************************************* *)
 
 (** [Description] : Affiche l'image de la famille d'une personne en réponse HTTP.
@@ -123,8 +123,8 @@ let print_portrait conf base p =
       - p : personne dans la base dont il faut afficher l'image de la famille
     [Retour] : aucun
     [Rem] : Ne pas utiliser en dehors de ce module.                           *)
-let print_family_portrait conf base p =
-  match Image.get_family_portrait conf base p false with
+let print_blason conf base p =
+  match Image.get_blason conf base p false with
   | Some (`Path path) ->
       Result.fold ~ok:ignore
         ~error:(fun _ -> Hutil.incorrect_request conf)
@@ -160,7 +160,7 @@ let print_family conf base =
   | Some f -> print_source conf f
   | None -> (
       match Util.find_person_in_env conf base "" with
-      | Some p -> print_family_portrait conf base p
+      | Some p -> print_blason conf base p
       | None -> Hutil.incorrect_request conf)
 
 let print_html conf =

--- a/lib/imageDisplay.ml
+++ b/lib/imageDisplay.ml
@@ -124,7 +124,7 @@ let print_portrait conf base p =
     [Retour] : aucun
     [Rem] : Ne pas utiliser en dehors de ce module.                           *)
 let print_family_portrait conf base p =
-  match Image.get_family_portrait conf base p with
+  match Image.get_family_portrait conf base p false with
   | Some (`Path path) ->
       Result.fold ~ok:ignore
         ~error:(fun _ -> Hutil.incorrect_request conf)

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -3377,6 +3377,12 @@ and eval_bool_person_field conf base env (p, p_auth) = function
       | Some (`Path p) when Filename.extension p = ".stop" -> true
       | Some (`Path _p) -> true
       | Some (`Url _u) -> true)
+  | "has_blason_stop" -> (
+      match Image.get_blason conf base p true with
+      | None -> false
+      | Some (`Path p) when Filename.extension p = ".stop" -> true
+      | Some (`Path _p) -> false
+      | Some (`Url _u) -> false)
   | "has_image_url" | "has_portrait_url" -> (
       match Image.get_portrait conf base p with
       | Some (`Url _url) -> true

--- a/lib/perso.ml
+++ b/lib/perso.ml
@@ -1280,7 +1280,7 @@ let gen_string_of_img_sz max_w max_h conf base (p, p_auth) =
 
 let gen_string_of_fimg_sz max_w max_h conf base (p, p_auth) =
   if p_auth then
-    match Image.get_family_portrait_with_size conf base p false with
+    match Image.get_blason_with_size conf base p false with
     | Some (_, Some (w, h)) ->
         let w, h = Image.scale_to_fit ~max_w ~max_h ~w ~h in
         Format.sprintf " width=\"%d\" height=\"%d\"" w h
@@ -1291,9 +1291,9 @@ let gen_string_of_fimg_sz max_w max_h conf base (p, p_auth) =
 let string_of_image_size = gen_string_of_img_sz max_im_wid max_im_wid
 let string_of_image_medium_size = gen_string_of_img_sz 160 120
 let string_of_image_small_size = gen_string_of_img_sz 100 75
-let string_of_family_image_size = gen_string_of_fimg_sz max_im_wid max_im_wid
-let string_of_family_image_medium_size = gen_string_of_fimg_sz 160 120
-let string_of_family_image_small_size = gen_string_of_fimg_sz 100 75
+let string_of_blason_size = gen_string_of_fimg_sz max_im_wid max_im_wid
+let string_of_blason_medium_size = gen_string_of_fimg_sz 160 120
+let string_of_blason_small_size = gen_string_of_fimg_sz 100 75
 
 let get_sosa conf base env r p =
   try List.assoc (get_iper p) !r
@@ -3365,8 +3365,7 @@ and eval_bool_person_field conf base env (p, p_auth) = function
   | "has_history" -> has_history conf base p p_auth
   | "has_image" | "has_portrait" ->
       Image.get_portrait conf base p |> Option.is_some
-  | "has_family_image" ->
-      Image.get_family_portrait conf base p false |> Option.is_some
+  | "has_blason" -> Image.get_blason conf base p false |> Option.is_some
   | "has_image_url" | "has_portrait_url" -> (
       match Image.get_portrait conf base p with
       | Some (`Url _url) -> true
@@ -3375,8 +3374,8 @@ and eval_bool_person_field conf base env (p, p_auth) = function
       match Image.get_old_portrait conf base p with
       | Some (`Url _url) -> true
       | _ -> false)
-  | "has_old_family_image_url" -> (
-      match Image.get_old_family_portrait conf base p with
+  | "has_old_blason_url" -> (
+      match Image.get_old_blason conf base p with
       | Some (`Url _url) -> true
       | _ -> false)
   (* carrousel *)
@@ -3384,8 +3383,7 @@ and eval_bool_person_field conf base env (p, p_auth) = function
   | "has_old_carrousel" -> Image.get_carrousel_old_imgs conf base p <> []
   | "has_old_image" | "has_old_portrait" ->
       Image.get_old_portrait conf base p |> Option.is_some
-  | "has_old_family_image" | "has_old_family_portrait" ->
-      Image.get_old_family_portrait conf base p |> Option.is_some
+  | "has_old_blason" -> Image.get_old_blason conf base p |> Option.is_some
   | "has_nephews_or_nieces" -> has_nephews_or_nieces conf base p
   | "has_nobility_titles" -> p_auth && Util.nobtit conf base p <> []
   | "has_notes" | "has_pnotes" ->
@@ -3624,22 +3622,18 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
   | "image_size" -> string_of_image_size conf base ep |> str_val
   | "image_medium_size" -> string_of_image_medium_size conf base ep |> str_val
   | "image_small_size" -> string_of_image_small_size conf base ep |> str_val
-  | "family_image_size" -> string_of_family_image_size conf base ep |> str_val
-  | "family_image_medium_size" ->
-      string_of_family_image_medium_size conf base ep |> str_val
-  | "family_image_small_size" ->
-      string_of_family_image_small_size conf base ep |> str_val
+  | "blason_size" -> string_of_blason_size conf base ep |> str_val
+  | "blason_medium_size" -> string_of_blason_medium_size conf base ep |> str_val
+  | "blason_small_size" -> string_of_blason_small_size conf base ep |> str_val
   | "image_url" -> string_of_image_url conf base ep false |> safe_val
-  | "family_image_url" ->
-      string_of_family_image_url conf base ep false |> safe_val
+  | "blason_url" -> string_of_blason_url conf base ep false |> safe_val
   | "index" -> (
       match get_env "p_link" env with
       | Vbool _ -> null_val
       | _ -> get_iper p |> string_of_iper |> Mutil.encode |> safe_val)
   (* carrousel functions *)
   | "carrousel" -> Image.default_portrait_filename base p |> str_val
-  | "family_carrousel" ->
-      Image.default_family_portrait_filename base p |> str_val
+  | "family_carrousel" -> Image.default_blason_filename base p |> str_val
   | "carrousel_img_nbr" ->
       string_of_int (List.length (Image.get_carrousel_imgs conf base p))
       |> str_val
@@ -3660,15 +3654,15 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
       | Some (`Path s) -> str_val s
       | Some (`Url u) -> str_val u
       | None -> null_val)
-  | "family_image" -> (
+  | "blason" -> (
       (* TODO what do we want here? can we remove this? *)
-      match Image.get_family_portrait conf base p false with
+      match Image.get_blason conf base p false with
       | Some (`Path s) -> str_val s
       | Some (`Url u) -> str_val u
       | None -> null_val)
-  | "family_image_self" -> (
+  | "blason_self" -> (
       (* TODO what do we want here? can we remove this? *)
-      match Image.get_family_portrait conf base p true with
+      match Image.get_blason conf base p true with
       | Some (`Path s) -> str_val s
       | Some (`Url u) -> str_val u
       | None -> null_val)
@@ -3677,13 +3671,13 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
       | Some (`Path s) -> str_val (Filename.basename s)
       | Some (`Url u) -> str_val u (* ?? *)
       | None -> null_val)
-  | "family_image_name" -> (
-      match Image.get_family_portrait conf base p false with
+  | "blason_name" -> (
+      match Image.get_blason conf base p false with
       | Some (`Path s) -> str_val (Filename.basename s)
       | Some (`Url u) -> str_val u (* ?? *)
       | None -> null_val)
-  | "family_image_self_name" -> (
-      match Image.get_family_portrait conf base p true with
+  | "blason_self_name" -> (
+      match Image.get_blason conf base p true with
       | Some (`Path s) -> str_val (Filename.basename s)
       | Some (`Url u) -> str_val u (* ?? *)
       | None -> null_val)
@@ -3692,13 +3686,13 @@ and eval_str_person_field conf base env ((p, p_auth) as ep) = function
       | Some (`Path s) -> str_val s
       | Some (`Url u) -> str_val u
       | None -> null_val)
-  | "family_image_saved" -> (
-      match Image.get_old_family_portrait conf base p with
+  | "blason_saved" -> (
+      match Image.get_old_blason conf base p with
       | Some (`Path s) -> str_val s
       | Some (`Url u) -> str_val u
       | None -> null_val)
-  | "family_image_saved_name" -> (
-      match Image.get_old_family_portrait conf base p with
+  | "blason_saved_name" -> (
+      match Image.get_old_blason conf base p with
       | Some (`Path s) -> str_val (Filename.basename s)
       | Some (`Url u) -> str_val u
       | None -> null_val)
@@ -4092,14 +4086,13 @@ and string_of_image_url conf base (p, p_auth) html : Adef.escaped_string =
     | None -> Adef.escaped ""
   else Adef.escaped ""
 
-and string_of_family_image_url conf base (p, p_auth) html : Adef.escaped_string
-    =
+and string_of_blason_url conf base (p, p_auth) html : Adef.escaped_string =
   if p_auth then
-    match Image.get_family_portrait conf base p false with
+    match Image.get_blason conf base p false with
     | Some (`Path fname) ->
         let s = Unix.stat fname in
         let b = acces conf base p in
-        let k = Image.default_family_portrait_filename base p in
+        let k = Image.default_blason_filename base p in
         Format.sprintf "%sm=FIM%s&d=%d&%s&k=/%s"
           (commd conf :> string)
           (if html then "H" else "")


### PR DESCRIPTION
WIP. 
cette PR couvre le code de image.ml, perso.ml et imageCarrousel.
les fichiers template séparément ci-dessous

Le blason est défini pour l'ancêtre "racine" (on verra plus tard comment "remonter" ce blason si on ajoute un ancêtre).
Un blason est défini par fn.oc.sn.blason.ext (voir plus tard le cas du changement de pnox)
Un blason fn.oc.sn.blason.stop interromp la transmission du blason aux descendants (voir plus tard comment le créer)

la commande %blason; cherche un blason à travers la lignée paternelle. On s'arrête au premier blason rencontré, y compris un blason stop (qui n'affiche rien)
Le carrousel affiche les blasons stop
la commande %blason_self; ne fait pas la recherche ci-dessus

A suivre
[henri.zip](https://github.com/mdelambilly/geneweb/files/14747242/henri.zip)
